### PR TITLE
feat(CORE/Module): Gain Honor from Killing Guards and Elites

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-AC_ADD_SCRIPT("${CMAKE_CURRENT_LIST_DIR}/src/MyPlayer.cpp")
-AC_ADD_SCRIPT_LOADER("MyPlayer" "${CMAKE_CURRENT_LIST_DIR}/src/loader.h")
+AC_ADD_SCRIPT("${CMAKE_CURRENT_LIST_DIR}/src/GainHonorGuard.cpp")
+AC_ADD_SCRIPT_LOADER("GainHonorGuard" "${CMAKE_CURRENT_LIST_DIR}/src/loader.h")
 
-AC_ADD_CONFIG_FILE("${CMAKE_CURRENT_LIST_DIR}/conf/my_custom.conf.dist")
+AC_ADD_CONFIG_FILE("${CMAKE_CURRENT_LIST_DIR}/conf/GainHonorGuard.conf.dist")

--- a/conf/GainHonorGuard.conf.dist
+++ b/conf/GainHonorGuard.conf.dist
@@ -1,0 +1,72 @@
+[worldserver]
+
+###################################################################################################
+#  GainHonorGuard
+###################################################################################################
+
+# Enable the module? (1: true | 0: false)
+GainHonorGuard.Enable = 1
+
+# Announce the module when the player logs in?
+GainHonorGuard.Announce = 1
+
+###################################################################################################
+# Gain Honor Settings
+###################################################################################################
+
+# GainHonorOnGuardKill
+# Set it to 1 to gain honor when you kill a guard.
+# Note that not all city guards will give you honor. It seems only capital and big city guards are flagged
+# as so in the database.
+# Default : 0 (No honor when you kill a guard)
+
+GainHonorGuard.GainHonorOnGuardKill = 0
+
+# GainHonorOnEliteKill
+# Set it to 1 to gain honor when you kill an elite mob (this does not apply on rare mob, unless he is also elite).
+# Default : 0 (No honor when you kill an elite mob)
+
+GainHonorGuard.GainHonorOnEliteKill = 0
+
+
+###################################################################################################
+# Announce Honor Gained 
+###################################################################################################
+
+# GainHonorOnGuardKillAnnounce
+# Announce to player how much honor gained when player kills a non-gray guard. 
+# Must enable GainHonorOnGuardKill for this to work 
+# Default : 0 (Disabled)
+
+GainHonorGuard.GainHonorOnGuardKillAnnounce = 0
+
+# GainHonorOnEliteKillAnnounce
+# Announce to player how much honor gained when player kills a non-gray elite creature. 
+# Must enable GainHonorOnEliteKill for this to work
+# Default : 0 (Disabled)
+
+GainHonorGuard.GainHonorOnEliteKillAnnounce = 0
+
+
+###################################################################################################
+# Honor Rate Settings
+###################################################################################################
+
+# GainHonorRateEnable
+# Enable the custom Honor Gain Rate to change the amount of Honor gained. 
+# The current rate is using the "honor_f *= sWorld->getRate(RATE_HONOR)" calculation.
+# This setting allows you to change the RATE_HONOR value to a different rate. 
+# Default : 0 (Disabled)
+
+GainHonorGuard.GainHonorRateEnable = 0
+
+# GainHonorRate
+# Rate multiplier to base Honor gained. 
+# Must enable GainHonorRateEnable for this to work
+# Example : 0.5 will half Honor gained
+# Default : 1.0 (Standard RATE_HONOR)
+
+GainHonorGuard.GainHonorRate = 1.0
+
+
+###################################################################################################

--- a/src/GainHonorGuard.cpp
+++ b/src/GainHonorGuard.cpp
@@ -1,0 +1,214 @@
+/**
+    This plugin can be used for common player customizations
+ */
+
+#include "ScriptMgr.h"
+#include "Player.h"
+#include "Pet.h"
+#include "Config.h"
+#include "Formulas.h"
+#include "Chat.h"
+#include "Group.h"
+#include "Unit.h"
+#include "World.h"
+#include "WorldPacket.h"
+
+bool GainHonorGuardEnable = 1;
+bool GainHonorGuardAnnounceModule = 1;
+bool GainHonorGuardOnGuardKill = 1;
+bool GainHonorGuardOnEliteKill = 1;
+bool GainHonorGuardOnGuardKillAnnounce = 1;
+bool GainHonorGuardOnEliteKillAnnounce = 1;
+bool GainHonorRateEnable = 1;
+float GainHonorRate = 1.0;
+
+class GainHonorGuardConfig : public WorldScript
+{
+public:
+    GainHonorGuardConfig() : WorldScript("GainHonorGuardConfig") {}
+
+    void OnBeforeConfigLoad(bool reload) override
+    {
+        if (!reload) {
+            std::string conf_path = _CONF_DIR;
+            std::string cfg_file = conf_path + "/GainHonorGuard.conf";
+
+            std::string cfg_def_file = cfg_file + ".dist";
+            sConfigMgr->LoadMore(cfg_def_file.c_str());
+            sConfigMgr->LoadMore(cfg_file.c_str());
+
+            // Load Configuration Settings
+            SetInitialWorldSettings();
+        }
+    }
+
+    // Load Configuration Settings
+    void SetInitialWorldSettings()
+    {
+		GainHonorGuardEnable = sConfigMgr->GetBoolDefault("GainHonorGuard.Enable", 1);
+        GainHonorGuardAnnounceModule = sConfigMgr->GetBoolDefault("GainHonorGuard.Announce", 1);
+		
+		//Gain Honor Settings
+		GainHonorGuardOnGuardKill = sConfigMgr->GetBoolDefault("GainHonorGuard.GainHonorOnGuardKill", 0);
+        GainHonorGuardOnEliteKill = sConfigMgr->GetBoolDefault("GainHonorGuard.GainHonorOnEliteKill", 0);	
+
+		//Announce honor gained
+		GainHonorGuardOnGuardKillAnnounce = sConfigMgr->GetBoolDefault("GainHonorGuard.GainHonorOnGuardKillAnnounce", 0);
+		GainHonorGuardOnEliteKillAnnounce = sConfigMgr->GetBoolDefault("GainHonorGuard.GainHonorOnEliteKillAnnounce", 0);
+
+		//Honor Rate
+		GainHonorRateEnable = sConfigMgr->GetBoolDefault("GainHonorGuard.GainHonorRateEnable", 0);
+		GainHonorRate = abs(sConfigMgr->GetFloatDefault("GainHonorGuard.GainHonorRate", 1.0));
+	}
+};
+
+class GainHonorGuardAnnouce : public PlayerScript
+{
+
+public:
+
+    GainHonorGuardAnnouce() : PlayerScript("GainHonorGuard") {}
+
+    void OnLogin(Player* player) override 
+	{
+	
+		// Announce Module
+        if (GainHonorGuardEnable)
+        {
+            if (GainHonorGuardAnnounceModule)
+			{
+				ChatHandler(player->GetSession()).SendSysMessage("This server is running the |cff4CFF00GainHonorGuard |rmodule.");
+			}
+        }
+    }
+};
+
+class GainHonorGuard : public PlayerScript
+{
+
+public:
+
+    GainHonorGuard() : PlayerScript("GainHonorGuard") {}
+	
+    void OnCreatureKill(Player* player, Creature* killed)  //override
+    {
+		RewardHonor(player, killed);
+	}
+	
+    void OnCreatureKilledByPet(Player* player, Creature* killed) //override
+    {
+		RewardHonor(player, killed);
+	}
+
+	//Reward Honor from either a Guard (creature 32768 flag) or Elite kill.  
+	void RewardHonor(Player* player, Creature* killed)
+	{
+        if (GainHonorGuardEnable && player->IsAlive() && !player->InArena() && !player->HasAura(SPELL_AURA_PLAYER_INACTIVE))
+        {			
+			if (killed || !killed->HasAuraType(SPELL_AURA_NO_PVP_CREDIT))
+			{				
+				if ((GainHonorGuardOnGuardKill && killed->ToCreature()->IsGuard()) || (GainHonorGuardOnEliteKill && killed->ToCreature()->isElite()))
+				{
+				
+					std::ostringstream ss;		
+					int honor = -1; //Honor is added as an int
+					float honor_f = (float)honor; //Convert honor to float for calculations 
+					player->UpdateHonorFields();
+					
+					int groupsize = GetNumInGroup(player); //Determine if it was a gang beatdown
+					
+					//Determine level that is gray
+					uint8 k_level = player->getLevel();
+					uint8 k_grey = acore::XP::GetGrayLevel(k_level);
+					uint8 v_level = killed->getLevel();
+					
+					
+					// If guard or elite is grey to the player then no honor rewarded
+					if (v_level > k_grey)
+					{
+						honor_f = ceil(acore::Honor::hk_honor_at_level_f(k_level) * (v_level - k_grey) / (k_level - k_grey));
+
+						// count the number of playerkills in one day
+						player->ApplyModUInt32Value(PLAYER_FIELD_KILLS, 1, true);
+						// and those in a lifetime
+						player->ApplyModUInt32Value(PLAYER_FIELD_LIFETIME_HONORABLE_KILLS, 1, true);
+						player->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_EARN_HONORABLE_KILL);
+						player->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_HK_CLASS, killed->getClass());
+						player->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_HK_RACE, killed->getRace());
+						player->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_HONORABLE_KILL_AT_AREA, player->GetAreaId());
+						player->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_HONORABLE_KILL, 1, 0, killed);
+						
+						
+						if (killed != nullptr)
+						{
+							//A Gang beatdown of an enemy rewards less honor 
+							if (groupsize > 1)
+								honor_f /= groupsize;
+
+							// apply honor multiplier from aura (not stacking-get highest)
+							AddPct(honor_f, player->GetMaxPositiveAuraModifier(SPELL_AURA_MOD_HONOR_GAIN_PCT));
+						}
+
+						//Custom Gain Honor Rate 
+						if (GainHonorRateEnable)
+						{
+							honor_f *= GainHonorRate;
+						}
+						else
+						{
+							honor_f *= sWorld->getRate(RATE_HONOR);
+						}
+						
+						//sLog->outError("%u: gained honor with a rate: %0.2f", player->GetGUID(), sWorld->getRate(RATE_HONOR));
+
+						// Convert Honor Back to an int to add to player
+						honor = int32(honor_f);
+						
+						//Not sure if this works.  
+						WorldPacket data(SMSG_PVP_CREDIT, 4 + 8 + 4);
+						data << honor;
+
+
+						// add honor points to player
+						player->ModifyHonorPoints(honor);
+
+						player->ApplyModUInt32Value(PLAYER_FIELD_TODAY_CONTRIBUTION, honor, true);
+						
+						//announce to player if honor was gained
+						if (GainHonorGuardOnGuardKill && killed->ToCreature()->IsGuard() && GainHonorGuardOnGuardKillAnnounce)
+						{
+							ss << "You have been awarded |cff4CFF00%i |rHonor.";
+							ChatHandler(player->GetSession()).PSendSysMessage(ss.str().c_str(), honor);
+						}
+						else if (GainHonorGuardOnEliteKill && killed->ToCreature()->isElite() && GainHonorGuardOnEliteKillAnnounce)
+						{
+							ss << "You have been awarded |cffFF8000%i |rHonor.";
+							ChatHandler(player->GetSession()).PSendSysMessage(ss.str().c_str(), honor);	
+						}						
+					}
+				}
+			}
+		}
+    }	
+
+    // Get the player's group size
+    int GetNumInGroup(Player* player) 
+	{
+        int numInGroup = 1;
+        Group *group = player->GetGroup();
+        if (group) {
+            Group::MemberSlotList const& groupMembers = group->GetMemberSlots();
+            numInGroup = groupMembers.size();
+		}
+        return numInGroup;
+    }
+	
+};
+
+
+void AddGainHonorGuardScripts() {
+	new GainHonorGuardConfig();
+	new GainHonorGuardAnnouce();
+    new GainHonorGuard();
+}
+

--- a/src/loader.h
+++ b/src/loader.h
@@ -1,1 +1,1 @@
-void AddMyPlayerScripts();
+void AddGainHonorGuardScripts();


### PR DESCRIPTION
This is the first build of the GainHonorGuard module
- Individuals Servers may be low-population or Solo.  This makes battlegrounds
not used very often.  This module gives another avenue to gaining Honor.

Module will allow Honor to be gained through killing Guards and/or elites.
Other features
- Allows modification of the rate of how much Honor is gained.
- Allows the option to announcement when Honor is gained.
- Allow announcement if the module is active.
- Allows separate activation of elites and guard honor gained.